### PR TITLE
fix(workspace): re-init when provider plugins are missing; surface real terraform errors (ops#114)

### DIFF
--- a/.github/workflows/build-push-konstructio.yaml
+++ b/.github/workflows/build-push-konstructio.yaml
@@ -1,0 +1,70 @@
+name: Build and Push (konstructio ghcr)
+
+# Builds the provider-terraform controller container and pushes it to
+# ghcr.io/konstructio/provider-terraform. This is the image referenced by the
+# control plane's crossplane DeploymentRuntimeConfig (the crossplane *package*
+# stays upstream; only the controller binary is overridden). The stock
+# "Publish Provider Package" workflow targets ghcr.io/crossplane-contrib and the
+# upbound mirror, so it cannot produce the konstructio image — hence this one.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Image tag (e.g. v0.0.1-rc.initfix)'
+        required: true
+        default: 'v0.0.1-rc.initfix'
+  push:
+    branches:
+      - 'main-civo'
+      - 'hotfix-*'
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  # Fresh package name so this repo's Actions token owns it (the pre-existing
+  # provider-terraform package doesn't grant this repo push access). New GHCR
+  # packages default to private; flip this one to public once created.
+  IMAGE: ghcr.io/konstructio/provider-terraform-initfix
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Resolve image tag
+        id: tag
+        run: |
+          TAG="${{ github.event.inputs.tag }}"
+          if [ -z "$TAG" ]; then TAG="branch-${GITHUB_SHA::8}"; fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Building ${IMAGE}:${TAG}"
+
+      - name: Build controller binary (linux/amd64)
+        run: |
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -o manager ./cmd/provider
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          # Root Dockerfile: the fork's image (kubectl provider mirror, /logs,
+          # gitconfig credential helper), not upstream's package image.
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.IMAGE }}:${{ steps.tag.outputs.tag }}

--- a/internal/controller/cluster/workspace/workspace.go
+++ b/internal/controller/cluster/workspace/workspace.go
@@ -466,11 +466,15 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 		if err != nil {
 			return nil, errors.Wrap(err, errChecksum)
 		}
-		if cr.Status.AtProvider.Checksum == checksum {
-			l.Debug("Checksums match - skip running terraform init")
+		if cr.Status.AtProvider.Checksum == checksum && terraform.ProvidersInstalled(c.fs, terraformWorkDir) {
+			l.Debug("Checksums match and provider plugins present - skip running terraform init")
 			return &external{tf: tf, kube: c.kube, logger: c.logger}, errors.Wrap(tf.Workspace(ctx, meta.GetExternalName(cr)), errWorkspace)
 		}
-		l.Debug("Checksums don't match so run terraform init:", "old", cr.Status.AtProvider.Checksum, "new", checksum)
+		if cr.Status.AtProvider.Checksum == checksum {
+			l.Debug("Checksums match but provider plugins missing - running terraform init")
+		} else {
+			l.Debug("Checksums don't match so run terraform init:", "old", cr.Status.AtProvider.Checksum, "new", checksum)
+		}
 	}
 
 	o := make([]terraform.InitOption, 0, len(cr.Spec.ForProvider.InitArgs))

--- a/internal/controller/cluster/workspace/workspace_test.go
+++ b/internal/controller/cluster/workspace/workspace_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	goruntime "runtime"
 	"strings"
 	"testing"
 
@@ -117,6 +118,22 @@ func (tf *MockTf) Destroy(ctx context.Context, _ string, o ...terraform.Option) 
 
 func (tf *MockTf) DeleteCurrentWorkspace(ctx context.Context) error {
 	return tf.MockDeleteCurrentWorkspace(ctx)
+}
+
+// fsWithProviders returns a filesystem in which the workspace directory for uid
+// has a dependency lock file and the matching provider plugin present on disk,
+// i.e. the state in which Connect may safely skip terraform init.
+func fsWithProviders(uid types.UID) afero.Afero {
+	fs := afero.Afero{Fs: afero.NewMemMapFs()}
+	dir := filepath.Join(tfDir, string(uid))
+	lock := `provider "registry.terraform.io/hashicorp/null" {
+  version = "3.2.1"
+}
+`
+	_ = fs.WriteFile(filepath.Join(dir, ".terraform.lock.hcl"), []byte(lock), 0o644)
+	plugin := filepath.Join(dir, ".terraform", "providers", "registry.terraform.io", "hashicorp", "null", "3.2.1", goruntime.GOOS+"_"+goruntime.GOARCH)
+	_ = fs.WriteFile(filepath.Join(plugin, "terraform-provider-null"), []byte("bin"), 0o755)
+	return fs
 }
 
 func TestConnect(t *testing.T) {
@@ -678,7 +695,42 @@ func TestConnect(t *testing.T) {
 			want: errors.Wrap(errBoom, errChecksum),
 		},
 		"ChecksumMatches": {
-			reason: "We should return any error when generating the workspace checksum",
+			reason: "We should skip terraform init when the checksum matches and the provider plugins are present on disk",
+			fields: fields{kube: &test.MockClient{
+				MockGet: test.NewMockGetFn(nil),
+			},
+				usage: tfClient.LegacyTrackerFn(func(_ context.Context, _ resource.LegacyManaged) error { return nil }),
+				fs:    fsWithProviders(uid),
+				terraform: func(_ string, _ bool, _ bool, _ logging.Logger, _ ...string) tfclient {
+					return &MockTf{
+						MockGenerateChecksum: func(ctx context.Context) (string, error) { return tfChecksum, nil },
+						MockWorkspace:        func(_ context.Context, _ string) error { return nil },
+					}
+				},
+			},
+			args: args{
+				mg: &v1beta1.Workspace{
+					ObjectMeta: metav1.ObjectMeta{UID: uid},
+					Spec: v1beta1.WorkspaceSpec{
+						ClusterManagedResourceSpec: xpv2.ClusterManagedResourceSpec{
+							ProviderConfigReference: &xpv2.Reference{},
+						},
+						ForProvider: v1beta1.WorkspaceParameters{
+							Module: "I'm HCL!",
+							Source: v1beta1.ModuleSourceInline,
+						},
+					},
+					Status: v1beta1.WorkspaceStatus{
+						AtProvider: v1beta1.WorkspaceObservation{
+							Checksum: tfChecksum,
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		"ChecksumMatchesButPluginsMissing": {
+			reason: "We should still run terraform init when the checksum matches but the provider plugins are missing from disk",
 			fields: fields{kube: &test.MockClient{
 				MockGet: test.NewMockGetFn(nil),
 			},
@@ -687,6 +739,7 @@ func TestConnect(t *testing.T) {
 				terraform: func(_ string, _ bool, _ bool, _ logging.Logger, _ ...string) tfclient {
 					return &MockTf{
 						MockGenerateChecksum: func(ctx context.Context) (string, error) { return tfChecksum, nil },
+						MockInit:             func(_ context.Context, _ ...terraform.InitOption) error { return nil },
 						MockWorkspace:        func(_ context.Context, _ string) error { return nil },
 					}
 				},

--- a/internal/controller/namespaced/workspace/workspace.go
+++ b/internal/controller/namespaced/workspace/workspace.go
@@ -466,11 +466,15 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 		if err != nil {
 			return nil, errors.Wrap(err, errChecksum)
 		}
-		if cr.Status.AtProvider.Checksum == checksum {
-			l.Debug("Checksums match - skip running terraform init")
+		if cr.Status.AtProvider.Checksum == checksum && terraform.ProvidersInstalled(c.fs, terraformWorkDir) {
+			l.Debug("Checksums match and provider plugins present - skip running terraform init")
 			return &external{tf: tf, kube: c.kube, logger: c.logger}, errors.Wrap(tf.Workspace(ctx, meta.GetExternalName(cr)), errWorkspace)
 		}
-		l.Debug("Checksums don't match so run terraform init:", "old", cr.Status.AtProvider.Checksum, "new", checksum)
+		if cr.Status.AtProvider.Checksum == checksum {
+			l.Debug("Checksums match but provider plugins missing - running terraform init")
+		} else {
+			l.Debug("Checksums don't match so run terraform init:", "old", cr.Status.AtProvider.Checksum, "new", checksum)
+		}
 	}
 
 	o := make([]terraform.InitOption, 0, len(cr.Spec.ForProvider.InitArgs))

--- a/internal/controller/namespaced/workspace/workspace_test.go
+++ b/internal/controller/namespaced/workspace/workspace_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	goruntime "runtime"
 	"testing"
 
 	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
@@ -116,6 +117,22 @@ func (tf *MockTf) Destroy(ctx context.Context, _ string, o ...terraform.Option) 
 
 func (tf *MockTf) DeleteCurrentWorkspace(ctx context.Context) error {
 	return tf.MockDeleteCurrentWorkspace(ctx)
+}
+
+// fsWithProviders returns a filesystem in which the workspace directory for uid
+// has a dependency lock file and the matching provider plugin present on disk,
+// i.e. the state in which Connect may safely skip terraform init.
+func fsWithProviders(uid types.UID) afero.Afero {
+	fs := afero.Afero{Fs: afero.NewMemMapFs()}
+	dir := filepath.Join(tfDir, string(uid))
+	lock := `provider "registry.terraform.io/hashicorp/null" {
+  version = "3.2.1"
+}
+`
+	_ = fs.WriteFile(filepath.Join(dir, ".terraform.lock.hcl"), []byte(lock), 0o644)
+	plugin := filepath.Join(dir, ".terraform", "providers", "registry.terraform.io", "hashicorp", "null", "3.2.1", goruntime.GOOS+"_"+goruntime.GOARCH)
+	_ = fs.WriteFile(filepath.Join(plugin, "terraform-provider-null"), []byte("bin"), 0o755)
+	return fs
 }
 
 func TestConnect(t *testing.T) {
@@ -808,7 +825,51 @@ func TestConnect(t *testing.T) {
 			want: errors.Wrap(errBoom, errChecksum),
 		},
 		"ChecksumMatches": {
-			reason: "We should return any error when generating the workspace checksum",
+			reason: "We should skip terraform init when the checksum matches and the provider plugins are present on disk",
+			fields: fields{kube: &test.MockClient{
+				MockGet: test.NewMockGetFn(nil),
+				MockScheme: func() *runtime.Scheme {
+					s := runtime.NewScheme()
+					if err := namespaced.AddToScheme(s); err != nil {
+						t.Fatal(err)
+					}
+					return s
+				},
+			},
+				usage: tfClient.ModernTrackerFn(func(_ context.Context, _ resource.ModernManaged) error { return nil }),
+				fs:    fsWithProviders(uid),
+				terraform: func(_ string, _ bool, _ bool, _ logging.Logger, _ ...string) tfclient {
+					return &MockTf{
+						MockGenerateChecksum: func(ctx context.Context) (string, error) { return tfChecksum, nil },
+						MockWorkspace:        func(_ context.Context, _ string) error { return nil },
+					}
+				},
+			},
+			args: args{
+				mg: &v1beta1.Workspace{
+					ObjectMeta: metav1.ObjectMeta{UID: uid},
+					Spec: v1beta1.WorkspaceSpec{
+						ManagedResourceSpec: xpv2.ManagedResourceSpec{
+							ProviderConfigReference: &xpv2.ProviderConfigReference{
+								Kind: "ClusterProviderConfig",
+							},
+						},
+						ForProvider: v1beta1.WorkspaceParameters{
+							Module: "I'm HCL!",
+							Source: v1beta1.ModuleSourceInline,
+						},
+					},
+					Status: v1beta1.WorkspaceStatus{
+						AtProvider: v1beta1.WorkspaceObservation{
+							Checksum: tfChecksum,
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		"ChecksumMatchesButPluginsMissing": {
+			reason: "We should still run terraform init when the checksum matches but the provider plugins are missing from disk",
 			fields: fields{kube: &test.MockClient{
 				MockGet: test.NewMockGetFn(nil),
 				MockScheme: func() *runtime.Scheme {
@@ -824,6 +885,7 @@ func TestConnect(t *testing.T) {
 				terraform: func(_ string, _ bool, _ bool, _ logging.Logger, _ ...string) tfclient {
 					return &MockTf{
 						MockGenerateChecksum: func(ctx context.Context) (string, error) { return tfChecksum, nil },
+						MockInit:             func(_ context.Context, _ ...terraform.InitOption) error { return nil },
 						MockWorkspace:        func(_ context.Context, _ string) error { return nil },
 					}
 				},

--- a/internal/terraform/providers_installed_test.go
+++ b/internal/terraform/providers_installed_test.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2021 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package terraform
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/spf13/afero"
+)
+
+const testLock = `
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "2.23.0"
+  constraints = "2.23.0"
+  hashes      = ["h1:abc"]
+}
+
+provider "registry.terraform.io/civo/civo" {
+  version = "1.0.35"
+  hashes  = ["h1:def"]
+}
+`
+
+// writePlugin creates a non-empty plugin dir for source@version under dir.
+func writePlugin(t *testing.T, fs afero.Fs, dir, source, version string) {
+	t.Helper()
+	p := filepath.Join(dir, ".terraform", "providers", filepath.FromSlash(source), version, runtime.GOOS+"_"+runtime.GOARCH)
+	if err := fs.MkdirAll(p, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := afero.WriteFile(fs, filepath.Join(p, "terraform-provider"), []byte("binary"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestProvidersInstalled(t *testing.T) {
+	const dir = "/tf/ws"
+	cases := map[string]struct {
+		setup func(t *testing.T, fs afero.Fs)
+		want  bool
+	}{
+		"NoLockFile": {
+			setup: func(t *testing.T, fs afero.Fs) {},
+			want:  false,
+		},
+		"AllPluginsPresent": {
+			setup: func(t *testing.T, fs afero.Fs) {
+				if err := afero.WriteFile(fs, filepath.Join(dir, ".terraform.lock.hcl"), []byte(testLock), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				writePlugin(t, fs, dir, "registry.terraform.io/hashicorp/kubernetes", "2.23.0")
+				writePlugin(t, fs, dir, "registry.terraform.io/civo/civo", "1.0.35")
+			},
+			want: true,
+		},
+		"OnePluginMissing": {
+			setup: func(t *testing.T, fs afero.Fs) {
+				if err := afero.WriteFile(fs, filepath.Join(dir, ".terraform.lock.hcl"), []byte(testLock), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				// Only install one of the two pinned providers; this is the
+				// partial-.terraform case that used to be skipped past init.
+				writePlugin(t, fs, dir, "registry.terraform.io/hashicorp/kubernetes", "2.23.0")
+			},
+			want: false,
+		},
+		"EmptyPluginDir": {
+			setup: func(t *testing.T, fs afero.Fs) {
+				if err := afero.WriteFile(fs, filepath.Join(dir, ".terraform.lock.hcl"), []byte(testLock), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				writePlugin(t, fs, dir, "registry.terraform.io/hashicorp/kubernetes", "2.23.0")
+				// civo plugin dir exists but is empty.
+				empty := filepath.Join(dir, ".terraform", "providers", "registry.terraform.io", "civo", "civo", "1.0.35", runtime.GOOS+"_"+runtime.GOARCH)
+				if err := fs.MkdirAll(empty, 0o755); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			fs := afero.NewMemMapFs()
+			tc.setup(t, fs)
+			if got := ProvidersInstalled(fs, dir); got != tc.want {
+				t.Errorf("ProvidersInstalled(%q) = %v, want %v", dir, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/terraform/terraform.go
+++ b/internal/terraform/terraform.go
@@ -30,6 +30,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -38,6 +39,7 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
 	"github.com/pkg/errors"
+	"github.com/spf13/afero"
 
 	"github.com/upbound/provider-terraform/pkg/metrics"
 )
@@ -100,17 +102,61 @@ func formatTerraformErrorOutput(errorOutput string) (string, string, error) {
 		return "", "", err
 	}
 
-	// Return the first line of the error output as the summary
+	// Return the first "Error: ..." line as the summary. Not every terraform
+	// failure emits that pattern (e.g. a missing provider plugin), so fall back
+	// to the last non-empty line rather than reporting an empty "Summary: .".
 	var summary string
-	lines := strings.Split(errorOutput, "\n")
-	if m := tfError.FindSubmatch([]byte(errorOutput)); len(lines) > 0 && len(m) > 1 {
+	if m := tfError.FindSubmatch([]byte(errorOutput)); len(m) > 1 {
 		summary = string(m[1])
+	}
+	if summary == "" {
+		lines := strings.Split(errorOutput, "\n")
+		for i := len(lines) - 1; i >= 0; i-- {
+			if s := strings.TrimSpace(lines[i]); s != "" {
+				summary = s
+				break
+			}
+		}
 	}
 
 	// base64FullErr := base64.StdEncoding.EncodeToString([]byte(errorOutput))
 	base64FullErr := base64.StdEncoding.EncodeToString(buffer.Bytes())
 
 	return summary, base64FullErr, nil
+}
+
+// providerBlock matches each provider entry in a terraform dependency lock file
+// (.terraform.lock.hcl), capturing the provider source address and its version.
+var providerBlock = regexp.MustCompile(`provider\s+"([^"]+)"\s*\{[^}]*?version\s*=\s*"([^"]+)"`)
+
+// ProvidersInstalled reports whether every provider plugin pinned in dir's
+// dependency lock file is actually present under .terraform/providers for the
+// current platform.
+//
+// A matching module checksum is not enough to safely skip `terraform init`: the
+// checksum is stored on the Workspace's status and survives provider Pod
+// restarts, but the plugins live on the Pod's ephemeral disk. After a restart or
+// a recreated working directory the plugins can be missing, and apply/destroy
+// then fails opaquely with "could not read package directory". Callers use this
+// to force a re-init whenever the plugins aren't on disk.
+func ProvidersInstalled(fs afero.Fs, dir string) bool {
+	lock, err := afero.ReadFile(fs, filepath.Join(dir, ".terraform.lock.hcl"))
+	if err != nil {
+		return false
+	}
+	matches := providerBlock.FindAllStringSubmatch(string(lock), -1)
+	if len(matches) == 0 {
+		return false
+	}
+	platform := runtime.GOOS + "_" + runtime.GOARCH
+	for _, m := range matches {
+		source, version := m[1], m[2]
+		entries, err := afero.ReadDir(fs, filepath.Join(dir, ".terraform", "providers", filepath.FromSlash(source), version, platform))
+		if err != nil || len(entries) == 0 {
+			return false
+		}
+	}
+	return true
 }
 
 // NOTE(negz): The gosec linter returns a G204 warning anytime a command is
@@ -733,6 +779,14 @@ func runCommand(ctx context.Context, c *exec.Cmd) ([]byte, error) {
 		}
 		return nil, errors.Wrap(err, errRunCommand)
 	case res := <-ch:
+		// c.Output() records the command's stderr on the *exec.ExitError, but
+		// terraform frequently prints the actual failure (e.g. a missing provider
+		// plugin) to stdout. When stderr is empty, fold stdout into the error so
+		// Classify surfaces something actionable instead of an empty summary.
+		var ee *exec.ExitError
+		if errors.As(res.err, &ee) && len(ee.Stderr) == 0 && len(res.out) > 0 {
+			ee.Stderr = res.out
+		}
 		return res.out, res.err
 	}
 }
@@ -776,6 +830,14 @@ func runCommandv2(ctx context.Context, c *exec.Cmd, f io.Writer) ([]byte, error)
 		}
 		return nil, errors.Wrap(err, errRunCommand)
 	case res := <-ch:
+		// c.Output() records the command's stderr on the *exec.ExitError, but
+		// terraform frequently prints the actual failure (e.g. a missing provider
+		// plugin) to stdout. When stderr is empty, fold stdout into the error so
+		// Classify surfaces something actionable instead of an empty summary.
+		var ee *exec.ExitError
+		if errors.As(res.err, &ee) && len(ee.Stderr) == 0 && len(res.out) > 0 {
+			ee.Stderr = res.out
+		}
 		return res.out, res.err
 	}
 }


### PR DESCRIPTION
## Problem (ops#114)
The terraform-backed `Workspace` intermittently failed **apply and destroy** with an opaque empty error (`Terraform encountered an error. Summary: .`).

Two root causes:
1. **Init skipped when plugins were actually gone.** `Connect` skips `terraform init` when the module checksum matches `Status.AtProvider.Checksum`. That checksum survives provider Pod restarts, but the plugins under `.terraform/providers` live on the Pod's **ephemeral** disk → after a restart the checksum still matched, init was skipped, and the next apply/destroy hit a missing provider plugin.
2. **The real error was swallowed.** terraform prints that failure to **stdout**, but `runCommand` used `c.Output()` (stderr only) → `Summary: .`.

Neither is fixed upstream: upstream's `validateTerraformLockFile` only gates the *module download* for `remotePullPolicy: IfNotPresent`, and `runCommand` still discards stdout.

## Fix
- `terraform.ProvidersInstalled(fs, dir)` — only skip `init` when every provider pinned in `.terraform.lock.hcl` is actually present on disk for this platform. Applied in **both** the cluster and namespaced controllers' `Connect`.
- `runCommand` / `runCommandv2` — fold stdout into the `ExitError` when stderr is empty so `Classify` surfaces something actionable.
- `formatTerraformErrorOutput` — fall back to the last non-empty line when there's no `Error:` line.
- `build-push-konstructio.yaml` workflow — now also runs on `main-civo` and builds the fork's root `Dockerfile` (kubectl provider mirror, `/logs`, gitconfig) rather than upstream's package image. Still pushes to `ghcr.io/konstructio/provider-terraform-initfix`; switching to the main `provider-terraform` package needs that package to grant this repo's Actions token push access (follow-up).

## Tests
- `TestProvidersInstalled`: all-present / one-missing / empty-plugin-dir / no-lock.
- `TestConnect/ChecksumMatches` (both controllers): now seeds a lock file + plugin on disk and proves init is **skipped** (the mock has no `MockInit`, so a call would panic).
- `TestConnect/ChecksumMatchesButPluginsMissing` (both controllers): empty fs, proves init **runs**.
- `go test ./...` green; `golangci-lint v2.13.1` (CI's version) reports 0 issues.

## History
Branch rebuilt on top of `main-civo` after #8 moved the fork onto upstream `main` (Crossplane v2 layout). The original 5 commits were squashed into one port: the lint/test-debt and `go.mod` commits were already delivered by #8 at the new paths, and the `//nolint:errcheck` commit is unnecessary under upstream's `.golangci.yml`. The fix logic is unchanged from the version validated live on konstruct-mgmt (`branch-a8e2f893`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)