### PR TITLE
fix(workspace): fall back to configured git credentials when the GitHub App secret is absent

### DIFF
--- a/internal/controller/workspace/github_app.go
+++ b/internal/controller/workspace/github_app.go
@@ -48,7 +48,7 @@ func getGitCredsFromGithubAppSecret(ctx context.Context, client client.Client) (
 
 	installationToken, err := generateInstallationToken(appID, installationID, privateKeyPEM)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get installation token: %w", &err)
+		return nil, fmt.Errorf("failed to get installation token: %w", err)
 	}
 
 	data := fmt.Sprintf("https://x-access-token:%s@github.com", installationToken)

--- a/internal/controller/workspace/workspace.go
+++ b/internal/controller/workspace/workspace.go
@@ -214,13 +214,19 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 		if cd.Filename != gitCredentialsFilename {
 			continue
 		}
-		// data, err := resource.CommonCredentialExtractor(ctx, cd.Source, c.kube, cd.CommonCredentialSelectors)
-		// if err != nil {
-		// 	return nil, errors.Wrap(err, errGetCreds)
-		// }
+		// Prefer GitHub App minted credentials when the github-app secret is
+		// present (SaaS installs); otherwise fall back to the credential source
+		// configured on the ProviderConfig. Hard-requiring the GitHub App
+		// secret breaks every GitLab-based install: Connect fails with
+		// "failed to get github app credentials secret" even for public module
+		// sources that need no git credentials at all.
 		data, err := getGitCredsFromGithubAppSecret(ctx, c.kube)
 		if err != nil {
-			return nil, errors.Wrap(err, errGetCreds)
+			var fallbackErr error
+			data, fallbackErr = resource.CommonCredentialExtractor(ctx, cd.Source, c.kube, cd.CommonCredentialSelectors)
+			if fallbackErr != nil {
+				return nil, errors.Wrap(fallbackErr, errGetCreds+" (github app secret also unavailable: "+err.Error()+")")
+			}
 		}
 
 		// NOTE(bobh66): Put the git credentials file in /tmp/tf/<UUID> so it doesn't get removed or overwritten


### PR DESCRIPTION
See commit message — restores CommonCredentialExtractor as the fallback when the github-app-credentials secret is absent (GitLab installs), keeps the GitHub App mint preferred when present. Also fixes the pre-existing %w-on-*error vet break in github_app.go. Validated live on forkthatrepo.com (Civo+GitLab, 0.7.0-rc.744ec200).