### PR TITLE
feat: multi-org GitHub App credentials via labeled secrets

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -1,2 +1,4 @@
 [credential]
 	helper = store --file=$GIT_CRED_DIR/.git-credentials
+	helper = store --file=/tmp/tf-github-app/.git-credentials
+	useHttpPath = true

--- a/gitconfig
+++ b/gitconfig
@@ -1,4 +1,3 @@
 [credential]
 	helper = store --file=$GIT_CRED_DIR/.git-credentials
-	helper = store --file=/tmp/tf-github-app/.git-credentials
 	useHttpPath = true

--- a/internal/controller/cluster/workspace/workspace.go
+++ b/internal/controller/cluster/workspace/workspace.go
@@ -19,6 +19,7 @@ package workspace
 import (
 	"context"
 	"encoding/json"
+	goerrors "errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -136,7 +137,7 @@ func Setup(mgr ctrl.Manager, o controller.Options, timeout, pollJitter time.Dura
 		terraform: func(dir string, usePluginCache bool, enableTerraformCLILogging bool, logger logging.Logger, envs ...string) tfclient {
 			return terraform.Harness{Path: tfPath, Dir: dir, UsePluginCache: usePluginCache, EnableTerraformCLILogging: enableTerraformCLILogging, Logger: logger, Envs: envs}
 		},
-		gitCreds: githubapp.Shared().EnsureCredentials,
+		gitCreds: githubapp.Shared().GitCredentials,
 	}
 
 	opts := []managed.ReconcilerOption{
@@ -187,9 +188,9 @@ type connector struct {
 	logger    logging.Logger
 	fs        afero.Afero
 	terraform func(dir string, usePluginCache bool, enableTerraformCLILogging bool, logger logging.Logger, envs ...string) tfclient
-	// gitCreds ensures GitHub App git credentials are available for module. It
+	// gitCreds returns the content of the .git-credentials file for module. It
 	// defaults to the shared githubapp.Manager; tests may override it.
-	gitCreds func(ctx context.Context, kube client.Client, module string) error
+	gitCreds func(ctx context.Context, kube client.Client, module string) ([]byte, error)
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) { //nolint:gocyclo
@@ -223,24 +224,29 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 			continue
 		}
 		// Prefer GitHub App tokens minted from the labeled secrets in
-		// crossplane-system (SaaS installs). The manager maintains a shared,
-		// path-scoped credentials file covering every installed org, so this
+		// crossplane-system (SaaS installs). The manager returns one
+		// path-scoped credentials line per installed org, so the same content
 		// also serves inline modules whose HCL references private github.com
-		// module sources. When no GitHub App credentials are usable, fall back
-		// to the credential source configured on the ProviderConfig (GitLab
-		// installs, or orgs where the App cannot be installed).
-		ensure := c.gitCreds
-		if ensure == nil {
-			ensure = githubapp.Shared().EnsureCredentials
+		// module sources. When App secrets exist they are authoritative: any
+		// failure surfaces here rather than being papered over by fallback
+		// credentials for the wrong org. Only when no App secrets exist at
+		// all do we fall back to the credential source configured on the
+		// ProviderConfig (GitLab installs).
+		gitCreds := c.gitCreds
+		if gitCreds == nil {
+			gitCreds = githubapp.Shared().GitCredentials
 		}
-		ghErr := ensure(ctx, c.kube, cr.Spec.ForProvider.Module)
-		if ghErr == nil {
-			continue
-		}
-		l.Debug("GitHub App credentials unavailable, falling back to ProviderConfig credentials", "error", ghErr.Error())
-		data, fallbackErr := resource.CommonCredentialExtractor(ctx, cd.Source, c.kube, cd.CommonCredentialSelectors)
-		if fallbackErr != nil {
-			return nil, errors.Wrap(fallbackErr, errGetCreds+" (github app: "+ghErr.Error()+")")
+		data, ghErr := gitCreds(ctx, c.kube, cr.Spec.ForProvider.Module)
+		if ghErr != nil {
+			if !goerrors.Is(ghErr, githubapp.ErrNoSecrets) {
+				return nil, errors.Wrap(ghErr, errGetCreds)
+			}
+			l.Debug("No GitHub App secrets, falling back to ProviderConfig credentials", "error", ghErr.Error())
+			var fallbackErr error
+			data, fallbackErr = resource.CommonCredentialExtractor(ctx, cd.Source, c.kube, cd.CommonCredentialSelectors)
+			if fallbackErr != nil {
+				return nil, errors.Wrap(fallbackErr, errGetCreds+" (github app: "+ghErr.Error()+")")
+			}
 		}
 		// NOTE(bobh66): Put the git credentials file in /tmp/tf/<UUID> so it doesn't get removed or overwritten
 		// by the remote module source case

--- a/internal/controller/cluster/workspace/workspace.go
+++ b/internal/controller/cluster/workspace/workspace.go
@@ -136,7 +136,7 @@ func Setup(mgr ctrl.Manager, o controller.Options, timeout, pollJitter time.Dura
 		terraform: func(dir string, usePluginCache bool, enableTerraformCLILogging bool, logger logging.Logger, envs ...string) tfclient {
 			return terraform.Harness{Path: tfPath, Dir: dir, UsePluginCache: usePluginCache, EnableTerraformCLILogging: enableTerraformCLILogging, Logger: logger, Envs: envs}
 		},
-		gitCreds: githubapp.GetGitCredsFromGithubAppSecret,
+		gitCreds: githubapp.Shared().EnsureCredentials,
 	}
 
 	opts := []managed.ReconcilerOption{
@@ -187,9 +187,9 @@ type connector struct {
 	logger    logging.Logger
 	fs        afero.Afero
 	terraform func(dir string, usePluginCache bool, enableTerraformCLILogging bool, logger logging.Logger, envs ...string) tfclient
-	// gitCreds returns the contents of the .git-credentials file. It defaults to
-	// minting a token from a GitHub App installation; tests may override it.
-	gitCreds func(ctx context.Context, kube client.Client) ([]byte, error)
+	// gitCreds ensures GitHub App git credentials are available for module. It
+	// defaults to the shared githubapp.Manager; tests may override it.
+	gitCreds func(ctx context.Context, kube client.Client, module string) error
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) { //nolint:gocyclo
@@ -222,23 +222,25 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 		if cd.Filename != gitCredentialsFilename {
 			continue
 		}
-		// Prefer GitHub App minted credentials when the github-app secret is
-		// present (SaaS installs); otherwise fall back to the credential source
-		// configured on the ProviderConfig. Hard-requiring the GitHub App
-		// secret breaks every GitLab-based install: Connect fails with
-		// "failed to get github app credentials secret" even for public module
-		// sources that need no git credentials at all.
-		gitCreds := c.gitCreds
-		if gitCreds == nil {
-			gitCreds = githubapp.GetGitCredsFromGithubAppSecret
+		// Prefer GitHub App tokens minted from the labeled secrets in
+		// crossplane-system (SaaS installs). The manager maintains a shared,
+		// path-scoped credentials file covering every installed org, so this
+		// also serves inline modules whose HCL references private github.com
+		// module sources. When no GitHub App credentials are usable, fall back
+		// to the credential source configured on the ProviderConfig (GitLab
+		// installs, or orgs where the App cannot be installed).
+		ensure := c.gitCreds
+		if ensure == nil {
+			ensure = githubapp.Shared().EnsureCredentials
 		}
-		data, err := gitCreds(ctx, c.kube)
-		if err != nil {
-			var fallbackErr error
-			data, fallbackErr = resource.CommonCredentialExtractor(ctx, cd.Source, c.kube, cd.CommonCredentialSelectors)
-			if fallbackErr != nil {
-				return nil, errors.Wrap(fallbackErr, errGetCreds+" (github app secret also unavailable: "+err.Error()+")")
-			}
+		ghErr := ensure(ctx, c.kube, cr.Spec.ForProvider.Module)
+		if ghErr == nil {
+			continue
+		}
+		l.Debug("GitHub App credentials unavailable, falling back to ProviderConfig credentials", "error", ghErr.Error())
+		data, fallbackErr := resource.CommonCredentialExtractor(ctx, cd.Source, c.kube, cd.CommonCredentialSelectors)
+		if fallbackErr != nil {
+			return nil, errors.Wrap(fallbackErr, errGetCreds+" (github app: "+ghErr.Error()+")")
 		}
 		// NOTE(bobh66): Put the git credentials file in /tmp/tf/<UUID> so it doesn't get removed or overwritten
 		// by the remote module source case

--- a/internal/controller/cluster/workspace/workspace_test.go
+++ b/internal/controller/cluster/workspace/workspace_test.go
@@ -1088,7 +1088,7 @@ provider "registry.terraform.io/hashicorp/aws" {
 				fs:        tc.fields.fs,
 				terraform: tc.fields.terraform,
 				logger:    logging.NewNopLogger(),
-				gitCreds:  func(context.Context, client.Client) ([]byte, error) { return []byte("creds"), nil },
+				gitCreds:  func(context.Context, client.Client, string) error { return errors.New("no github app") },
 			}
 			_, err := c.Connect(tc.args.ctx, tc.args.mg)
 

--- a/internal/controller/cluster/workspace/workspace_test.go
+++ b/internal/controller/cluster/workspace/workspace_test.go
@@ -42,6 +42,7 @@ import (
 
 	"github.com/upbound/provider-terraform/apis/cluster/v1beta1"
 	tfClient "github.com/upbound/provider-terraform/internal/clients"
+	"github.com/upbound/provider-terraform/internal/githubapp"
 	"github.com/upbound/provider-terraform/internal/terraform"
 )
 
@@ -1088,7 +1089,7 @@ provider "registry.terraform.io/hashicorp/aws" {
 				fs:        tc.fields.fs,
 				terraform: tc.fields.terraform,
 				logger:    logging.NewNopLogger(),
-				gitCreds:  func(context.Context, client.Client, string) error { return errors.New("no github app") },
+				gitCreds:  func(context.Context, client.Client, string) ([]byte, error) { return nil, githubapp.ErrNoSecrets },
 			}
 			_, err := c.Connect(tc.args.ctx, tc.args.mg)
 

--- a/internal/controller/namespaced/workspace/workspace.go
+++ b/internal/controller/namespaced/workspace/workspace.go
@@ -19,6 +19,7 @@ package workspace
 import (
 	"context"
 	"encoding/json"
+	goerrors "errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -136,7 +137,7 @@ func Setup(mgr ctrl.Manager, o controller.Options, timeout, pollJitter time.Dura
 		terraform: func(dir string, usePluginCache bool, enableTerraformCLILogging bool, logger logging.Logger, envs ...string) tfclient {
 			return terraform.Harness{Path: tfPath, Dir: dir, UsePluginCache: usePluginCache, EnableTerraformCLILogging: enableTerraformCLILogging, Logger: logger, Envs: envs}
 		},
-		gitCreds: githubapp.Shared().EnsureCredentials,
+		gitCreds: githubapp.Shared().GitCredentials,
 	}
 
 	opts := []managed.ReconcilerOption{
@@ -187,9 +188,9 @@ type connector struct {
 	logger    logging.Logger
 	fs        afero.Afero
 	terraform func(dir string, usePluginCache bool, enableTerraformCLILogging bool, logger logging.Logger, envs ...string) tfclient
-	// gitCreds ensures GitHub App git credentials are available for module. It
+	// gitCreds returns the content of the .git-credentials file for module. It
 	// defaults to the shared githubapp.Manager; tests may override it.
-	gitCreds func(ctx context.Context, kube client.Client, module string) error
+	gitCreds func(ctx context.Context, kube client.Client, module string) ([]byte, error)
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) { //nolint:gocyclo
@@ -223,24 +224,29 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 			continue
 		}
 		// Prefer GitHub App tokens minted from the labeled secrets in
-		// crossplane-system (SaaS installs). The manager maintains a shared,
-		// path-scoped credentials file covering every installed org, so this
+		// crossplane-system (SaaS installs). The manager returns one
+		// path-scoped credentials line per installed org, so the same content
 		// also serves inline modules whose HCL references private github.com
-		// module sources. When no GitHub App credentials are usable, fall back
-		// to the credential source configured on the ProviderConfig (GitLab
-		// installs, or orgs where the App cannot be installed).
-		ensure := c.gitCreds
-		if ensure == nil {
-			ensure = githubapp.Shared().EnsureCredentials
+		// module sources. When App secrets exist they are authoritative: any
+		// failure surfaces here rather than being papered over by fallback
+		// credentials for the wrong org. Only when no App secrets exist at
+		// all do we fall back to the credential source configured on the
+		// ProviderConfig (GitLab installs).
+		gitCreds := c.gitCreds
+		if gitCreds == nil {
+			gitCreds = githubapp.Shared().GitCredentials
 		}
-		ghErr := ensure(ctx, c.kube, cr.Spec.ForProvider.Module)
-		if ghErr == nil {
-			continue
-		}
-		l.Debug("GitHub App credentials unavailable, falling back to ProviderConfig credentials", "error", ghErr.Error())
-		data, fallbackErr := resource.CommonCredentialExtractor(ctx, cd.Source, c.kube, cd.CommonCredentialSelectors)
-		if fallbackErr != nil {
-			return nil, errors.Wrap(fallbackErr, errGetCreds+" (github app: "+ghErr.Error()+")")
+		data, ghErr := gitCreds(ctx, c.kube, cr.Spec.ForProvider.Module)
+		if ghErr != nil {
+			if !goerrors.Is(ghErr, githubapp.ErrNoSecrets) {
+				return nil, errors.Wrap(ghErr, errGetCreds)
+			}
+			l.Debug("No GitHub App secrets, falling back to ProviderConfig credentials", "error", ghErr.Error())
+			var fallbackErr error
+			data, fallbackErr = resource.CommonCredentialExtractor(ctx, cd.Source, c.kube, cd.CommonCredentialSelectors)
+			if fallbackErr != nil {
+				return nil, errors.Wrap(fallbackErr, errGetCreds+" (github app: "+ghErr.Error()+")")
+			}
 		}
 		// NOTE(bobh66): Put the git credentials file in /tmp/tf/<UUID> so it doesn't get removed or overwritten
 		// by the remote module source case

--- a/internal/controller/namespaced/workspace/workspace.go
+++ b/internal/controller/namespaced/workspace/workspace.go
@@ -136,7 +136,7 @@ func Setup(mgr ctrl.Manager, o controller.Options, timeout, pollJitter time.Dura
 		terraform: func(dir string, usePluginCache bool, enableTerraformCLILogging bool, logger logging.Logger, envs ...string) tfclient {
 			return terraform.Harness{Path: tfPath, Dir: dir, UsePluginCache: usePluginCache, EnableTerraformCLILogging: enableTerraformCLILogging, Logger: logger, Envs: envs}
 		},
-		gitCreds: githubapp.GetGitCredsFromGithubAppSecret,
+		gitCreds: githubapp.Shared().EnsureCredentials,
 	}
 
 	opts := []managed.ReconcilerOption{
@@ -187,9 +187,9 @@ type connector struct {
 	logger    logging.Logger
 	fs        afero.Afero
 	terraform func(dir string, usePluginCache bool, enableTerraformCLILogging bool, logger logging.Logger, envs ...string) tfclient
-	// gitCreds returns the contents of the .git-credentials file. It defaults to
-	// minting a token from a GitHub App installation; tests may override it.
-	gitCreds func(ctx context.Context, kube client.Client) ([]byte, error)
+	// gitCreds ensures GitHub App git credentials are available for module. It
+	// defaults to the shared githubapp.Manager; tests may override it.
+	gitCreds func(ctx context.Context, kube client.Client, module string) error
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) { //nolint:gocyclo
@@ -222,23 +222,25 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 		if cd.Filename != gitCredentialsFilename {
 			continue
 		}
-		// Prefer GitHub App minted credentials when the github-app secret is
-		// present (SaaS installs); otherwise fall back to the credential source
-		// configured on the ProviderConfig. Hard-requiring the GitHub App
-		// secret breaks every GitLab-based install: Connect fails with
-		// "failed to get github app credentials secret" even for public module
-		// sources that need no git credentials at all.
-		gitCreds := c.gitCreds
-		if gitCreds == nil {
-			gitCreds = githubapp.GetGitCredsFromGithubAppSecret
+		// Prefer GitHub App tokens minted from the labeled secrets in
+		// crossplane-system (SaaS installs). The manager maintains a shared,
+		// path-scoped credentials file covering every installed org, so this
+		// also serves inline modules whose HCL references private github.com
+		// module sources. When no GitHub App credentials are usable, fall back
+		// to the credential source configured on the ProviderConfig (GitLab
+		// installs, or orgs where the App cannot be installed).
+		ensure := c.gitCreds
+		if ensure == nil {
+			ensure = githubapp.Shared().EnsureCredentials
 		}
-		data, err := gitCreds(ctx, c.kube)
-		if err != nil {
-			var fallbackErr error
-			data, fallbackErr = resource.CommonCredentialExtractor(ctx, cd.Source, c.kube, cd.CommonCredentialSelectors)
-			if fallbackErr != nil {
-				return nil, errors.Wrap(fallbackErr, errGetCreds+" (github app secret also unavailable: "+err.Error()+")")
-			}
+		ghErr := ensure(ctx, c.kube, cr.Spec.ForProvider.Module)
+		if ghErr == nil {
+			continue
+		}
+		l.Debug("GitHub App credentials unavailable, falling back to ProviderConfig credentials", "error", ghErr.Error())
+		data, fallbackErr := resource.CommonCredentialExtractor(ctx, cd.Source, c.kube, cd.CommonCredentialSelectors)
+		if fallbackErr != nil {
+			return nil, errors.Wrap(fallbackErr, errGetCreds+" (github app: "+ghErr.Error()+")")
 		}
 		// NOTE(bobh66): Put the git credentials file in /tmp/tf/<UUID> so it doesn't get removed or overwritten
 		// by the remote module source case

--- a/internal/controller/namespaced/workspace/workspace_test.go
+++ b/internal/controller/namespaced/workspace/workspace_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-terraform/apis/namespaced"
 	"github.com/upbound/provider-terraform/apis/namespaced/v1beta1"
 	tfClient "github.com/upbound/provider-terraform/internal/clients"
+	"github.com/upbound/provider-terraform/internal/githubapp"
 	"github.com/upbound/provider-terraform/internal/terraform"
 )
 
@@ -1019,7 +1020,7 @@ func TestConnect(t *testing.T) {
 				fs:        tc.fields.fs,
 				terraform: tc.fields.terraform,
 				logger:    logging.NewNopLogger(),
-				gitCreds:  func(context.Context, client.Client, string) error { return errors.New("no github app") },
+				gitCreds:  func(context.Context, client.Client, string) ([]byte, error) { return nil, githubapp.ErrNoSecrets },
 			}
 			_, err := c.Connect(tc.args.ctx, tc.args.mg)
 			if diff := cmp.Diff(tc.want, err, test.EquateErrors()); diff != "" {

--- a/internal/controller/namespaced/workspace/workspace_test.go
+++ b/internal/controller/namespaced/workspace/workspace_test.go
@@ -1019,7 +1019,7 @@ func TestConnect(t *testing.T) {
 				fs:        tc.fields.fs,
 				terraform: tc.fields.terraform,
 				logger:    logging.NewNopLogger(),
-				gitCreds:  func(context.Context, client.Client) ([]byte, error) { return []byte("creds"), nil },
+				gitCreds:  func(context.Context, client.Client, string) error { return errors.New("no github app") },
 			}
 			_, err := c.Connect(tc.args.ctx, tc.args.mg)
 			if diff := cmp.Diff(tc.want, err, test.EquateErrors()); diff != "" {

--- a/internal/githubapp/githubapp.go
+++ b/internal/githubapp/githubapp.go
@@ -6,14 +6,15 @@
 // same App installed in several orgs is several Secrets sharing app_id and
 // private key but with distinct installation_ids). For every discovered Secret
 // the manager mints an installation token, resolves which org the installation
-// belongs to, and writes one path-scoped line per org into a single shared git
-// credentials file:
+// belongs to, and renders one path-scoped git credentials line per org:
 //
 //	https://x-access-token:<token>@github.com/<org>
 //
-// Together with `useHttpPath = true` in the container's gitconfig, git picks
-// the right token by repository path, so concurrent reconciles across orgs
-// share one file and cannot race each other's credentials.
+// The caller writes those lines into the workspace's own .git-credentials file
+// (the pre-existing $GIT_CRED_DIR flow). Because every workspace receives the
+// same content, concurrent reconciles across orgs stay consistent, and
+// `useHttpPath = true` in the container's gitconfig makes git pick the right
+// token by repository path.
 //
 // When the Workspace's module URL points at github.com, the manager also
 // probes the repository with the org's token (GET /repos/{org}/{repo}) so a
@@ -24,11 +25,11 @@ package githubapp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
-	"path/filepath"
 	"regexp"
 	"sort"
 	"strconv"
@@ -44,6 +45,13 @@ import (
 	"github.com/upbound/provider-terraform/pkg/metrics"
 )
 
+// ErrNoSecrets reports that no GitHub App secrets exist at all. It is the
+// only manager error on which callers should fall back to the ProviderConfig
+// credential source: when App secrets exist they are authoritative, and any
+// other failure must surface instead of being papered over by fallback
+// credentials for the wrong org.
+var ErrNoSecrets = errors.New("no github app secrets found")
+
 const (
 	// DefaultSecretNamespace is where GitHub App secrets are discovered.
 	DefaultSecretNamespace = "crossplane-system"
@@ -52,12 +60,6 @@ const (
 	// legacySecretName is the pre-label secret honored for backward
 	// compatibility even when it carries no label.
 	legacySecretName = "github-app-credentials"
-
-	// CredentialsDir holds the shared git credentials file. It must NOT live
-	// under /tmp/tf, which the workdir garbage collector prunes.
-	CredentialsDir = "/tmp/tf-github-app"
-	// CredentialsFile is referenced by the container's gitconfig.
-	CredentialsFile = ".git-credentials"
 
 	tokenRefreshMargin = 5 * time.Minute
 	probeTimeout       = 5 * time.Second
@@ -97,7 +99,6 @@ type Manager struct {
 	// overridable for tests
 	apiBase    string
 	httpClient *http.Client
-	credFile   string
 	now        func() time.Time
 }
 
@@ -119,7 +120,6 @@ func NewManager() *Manager {
 		tokens:     map[string]*tokenEntry{},
 		apiBase:    "https://api.github.com",
 		httpClient: &http.Client{Timeout: 30 * time.Second},
-		credFile:   filepath.Join(CredentialsDir, CredentialsFile),
 		now:        time.Now,
 	}
 }
@@ -135,19 +135,19 @@ func Shared() *Manager {
 	return shared
 }
 
-// EnsureCredentials makes sure every discoverable GitHub App installation has
-// a live token in the shared credentials file, and, when module points at a
-// github.com repository, verifies that one of those tokens can access it. It
-// returns an error when no GitHub App credentials are usable for module; the
-// caller is expected to fall back to the ProviderConfig's own credential
-// source.
-func (m *Manager) EnsureCredentials(ctx context.Context, kube client.Client, module string) error {
+// GitCredentials returns the content of a git credentials file covering every
+// discoverable GitHub App installation (one path-scoped line per org), and,
+// when module points at a github.com repository, verifies that one of those
+// tokens can access it. It returns ErrNoSecrets when no GitHub App secrets
+// exist; every other error means App secrets are present but unusable for
+// module and must not be silently replaced by fallback credentials.
+func (m *Manager) GitCredentials(ctx context.Context, kube client.Client, module string) ([]byte, error) {
 	secrets, err := m.discoverSecrets(ctx, kube)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if len(secrets) == 0 {
-		return fmt.Errorf("no github app secrets found in namespace %q (label %q or legacy %q)", m.namespace, m.label, legacySecretName)
+		return nil, fmt.Errorf("%w in namespace %q (label %q or legacy %q)", ErrNoSecrets, m.namespace, m.label, legacySecretName)
 	}
 
 	m.mu.Lock()
@@ -177,21 +177,19 @@ func (m *Manager) EnsureCredentials(ctx context.Context, kube client.Client, mod
 		}
 	}
 	if live == 0 {
-		return fmt.Errorf("no usable github app token: %s", strings.Join(failures, "; "))
-	}
-
-	if err := m.writeCredentialsFile(); err != nil {
-		return fmt.Errorf("cannot write git credentials file: %w", err)
+		return nil, fmt.Errorf("no usable github app token: %s", strings.Join(failures, "; "))
 	}
 
 	// When we can tell which repository the module needs, verify access so a
 	// scope problem surfaces here with a clear message instead of failing the
 	// clone. Modules that don't point at github.com (or inline HCL whose
-	// nested module sources we cannot see) are served by the file as a whole.
+	// nested module sources we cannot see) are served by the lines as a whole.
 	if org, repo := ParseGitHubRepo(module); org != "" {
-		return m.verifyRepoAccess(ctx, org, repo, failures)
+		if err := m.verifyRepoAccess(ctx, org, repo, failures); err != nil {
+			return nil, err
+		}
 	}
-	return nil
+	return m.credentialLines(), nil
 }
 
 func (m *Manager) discoverSecrets(ctx context.Context, kube client.Client) ([]v1.Secret, error) {
@@ -323,9 +321,9 @@ func suffix(failures []string) string {
 	return " (" + strings.Join(failures, "; ") + ")"
 }
 
-// writeCredentialsFile atomically rewrites the shared credentials file with
-// one path-scoped line per live token. Callers must hold m.mu.
-func (m *Manager) writeCredentialsFile() error {
+// credentialLines renders one path-scoped credentials line per live token, in
+// stable order. Callers must hold m.mu.
+func (m *Manager) credentialLines() []byte {
 	var b strings.Builder
 	for _, name := range m.sortedTokenNames() {
 		t := m.tokens[name]
@@ -334,24 +332,7 @@ func (m *Manager) writeCredentialsFile() error {
 		}
 		fmt.Fprintf(&b, "https://x-access-token:%s@github.com/%s\n", t.token, t.org)
 	}
-	dir := filepath.Dir(m.credFile)
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return err
-	}
-	tmp, err := os.CreateTemp(dir, CredentialsFile+".*")
-	if err != nil {
-		return err
-	}
-	if _, err := tmp.WriteString(b.String()); err != nil {
-		_ = tmp.Close()
-		_ = os.Remove(tmp.Name())
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		_ = os.Remove(tmp.Name())
-		return err
-	}
-	return os.Rename(tmp.Name(), m.credFile)
+	return []byte(b.String())
 }
 
 func (m *Manager) sortedTokenNames() []string {

--- a/internal/githubapp/githubapp.go
+++ b/internal/githubapp/githubapp.go
@@ -1,4 +1,24 @@
-// Package githubapp resolves git credentials from a GitHub App installation.
+// Package githubapp resolves git credentials for remote Terraform modules from
+// GitHub App installations.
+//
+// GitHub App credentials are discovered from Secrets in the configured
+// namespace carrying the configured label (one Secret per installation; the
+// same App installed in several orgs is several Secrets sharing app_id and
+// private key but with distinct installation_ids). For every discovered Secret
+// the manager mints an installation token, resolves which org the installation
+// belongs to, and writes one path-scoped line per org into a single shared git
+// credentials file:
+//
+//	https://x-access-token:<token>@github.com/<org>
+//
+// Together with `useHttpPath = true` in the container's gitconfig, git picks
+// the right token by repository path, so concurrent reconciles across orgs
+// share one file and cannot race each other's credentials.
+//
+// When the Workspace's module URL points at github.com, the manager also
+// probes the repository with the org's token (GET /repos/{org}/{repo}) so a
+// "the App is not installed there / the repo is not granted" failure surfaces
+// as a clear Connect error instead of an opaque clone failure.
 package githubapp
 
 import (
@@ -7,7 +27,13 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
 	"strconv"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -18,101 +44,421 @@ import (
 	"github.com/upbound/provider-terraform/pkg/metrics"
 )
 
-// installationTokenResponse represents the GitHub API response for installation token creation.
+const (
+	// DefaultSecretNamespace is where GitHub App secrets are discovered.
+	DefaultSecretNamespace = "crossplane-system"
+	// DefaultSecretLabel marks a Secret as GitHub App credentials.
+	DefaultSecretLabel = "tf.konstruct.io/github-app"
+	// legacySecretName is the pre-label secret honored for backward
+	// compatibility even when it carries no label.
+	legacySecretName = "github-app-credentials"
+
+	// CredentialsDir holds the shared git credentials file. It must NOT live
+	// under /tmp/tf, which the workdir garbage collector prunes.
+	CredentialsDir = "/tmp/tf-github-app"
+	// CredentialsFile is referenced by the container's gitconfig.
+	CredentialsFile = ".git-credentials"
+
+	tokenRefreshMargin = 5 * time.Minute
+	probeTimeout       = 5 * time.Second
+)
+
+// installationTokenResponse represents the GitHub API response for
+// installation token creation.
 type installationTokenResponse struct {
 	Token     string    `json:"token"`
 	ExpiresAt time.Time `json:"expires_at"`
 }
 
-func GetGitCredsFromGithubAppSecret(ctx context.Context, client client.Client) ([]byte, error) {
-	secret := v1.Secret{}
-	if err := client.Get(ctx, types.NamespacedName{
-		Name:      "github-app-credentials",
-		Namespace: "crossplane-system",
-	}, &secret); err != nil {
-		return nil, fmt.Errorf("failed to get github app credentials secret: %w", err)
-	}
-
-	privateKeyPEM := string(secret.Data["github_app_private_key"])
-
-	appIDStr := string(secret.Data["app_id"])
-	appID, err := strconv.ParseInt(appIDStr, 10, 64)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse app_id from secret: %w", err)
-	}
-
-	installIDStr := string(secret.Data["installation_id"])
-	installationID, err := strconv.ParseInt(installIDStr, 10, 64)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse installation_id from secret: %w", err)
-	}
-
-	installationToken, err := generateInstallationToken(ctx, appID, installationID, privateKeyPEM)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get installation token: %w", err)
-	}
-
-	data := fmt.Sprintf("https://x-access-token:%s@github.com", installationToken)
-
-	return []byte(data), nil
+type tokenEntry struct {
+	org       string
+	token     string
+	expiresAt time.Time
+	secretRV  string
+	// probed caches repositories this token has been verified against, so the
+	// probe runs once per token lifetime rather than once per reconcile.
+	probed map[string]bool
 }
 
-func generateInstallationToken(ctx context.Context, appID, installationID int64, privateKeyPEM string) (string, error) {
-	// Parse the RSA private key from PEM
-	key, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(privateKeyPEM))
+func (t *tokenEntry) live(now time.Time) bool {
+	return t != nil && t.expiresAt.Sub(now) > tokenRefreshMargin
+}
+
+// Manager mints and caches GitHub App installation tokens for every labeled
+// secret and maintains the shared git credentials file. It is safe for
+// concurrent use.
+type Manager struct {
+	namespace string
+	label     string
+
+	mu     sync.Mutex
+	tokens map[string]*tokenEntry // key: secret name
+
+	// overridable for tests
+	apiBase    string
+	httpClient *http.Client
+	credFile   string
+	now        func() time.Time
+}
+
+// NewManager returns a Manager with production defaults. Namespace and label
+// may be overridden with the GITHUB_APP_SECRET_NAMESPACE and
+// GITHUB_APP_SECRET_LABEL environment variables.
+func NewManager() *Manager {
+	ns := os.Getenv("GITHUB_APP_SECRET_NAMESPACE")
+	if ns == "" {
+		ns = DefaultSecretNamespace
+	}
+	label := os.Getenv("GITHUB_APP_SECRET_LABEL")
+	if label == "" {
+		label = DefaultSecretLabel
+	}
+	return &Manager{
+		namespace:  ns,
+		label:      label,
+		tokens:     map[string]*tokenEntry{},
+		apiBase:    "https://api.github.com",
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+		credFile:   filepath.Join(CredentialsDir, CredentialsFile),
+		now:        time.Now,
+	}
+}
+
+var (
+	shared     *Manager
+	sharedOnce sync.Once
+)
+
+// Shared returns the process-wide Manager used by the workspace controllers.
+func Shared() *Manager {
+	sharedOnce.Do(func() { shared = NewManager() })
+	return shared
+}
+
+// EnsureCredentials makes sure every discoverable GitHub App installation has
+// a live token in the shared credentials file, and, when module points at a
+// github.com repository, verifies that one of those tokens can access it. It
+// returns an error when no GitHub App credentials are usable for module; the
+// caller is expected to fall back to the ProviderConfig's own credential
+// source.
+func (m *Manager) EnsureCredentials(ctx context.Context, kube client.Client, module string) error {
+	secrets, err := m.discoverSecrets(ctx, kube)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse GitHub App private key: %w", err)
+		return err
+	}
+	if len(secrets) == 0 {
+		return fmt.Errorf("no github app secrets found in namespace %q (label %q or legacy %q)", m.namespace, m.label, legacySecretName)
 	}
 
-	now := time.Now()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var failures []string
+	for _, s := range secrets {
+		if err := m.ensureToken(ctx, s); err != nil {
+			failures = append(failures, fmt.Sprintf("secret %s: %v", s.Name, err))
+		}
+	}
+	// Drop cache entries whose secret is gone.
+	names := map[string]bool{}
+	for _, s := range secrets {
+		names[s.Name] = true
+	}
+	for name := range m.tokens {
+		if !names[name] {
+			delete(m.tokens, name)
+		}
+	}
+
+	live := 0
+	for _, t := range m.tokens {
+		if t.live(m.now()) {
+			live++
+		}
+	}
+	if live == 0 {
+		return fmt.Errorf("no usable github app token: %s", strings.Join(failures, "; "))
+	}
+
+	if err := m.writeCredentialsFile(); err != nil {
+		return fmt.Errorf("cannot write git credentials file: %w", err)
+	}
+
+	// When we can tell which repository the module needs, verify access so a
+	// scope problem surfaces here with a clear message instead of failing the
+	// clone. Modules that don't point at github.com (or inline HCL whose
+	// nested module sources we cannot see) are served by the file as a whole.
+	if org, repo := ParseGitHubRepo(module); org != "" {
+		return m.verifyRepoAccess(ctx, org, repo, failures)
+	}
+	return nil
+}
+
+func (m *Manager) discoverSecrets(ctx context.Context, kube client.Client) ([]v1.Secret, error) {
+	list := &v1.SecretList{}
+	if err := kube.List(ctx, list, client.InNamespace(m.namespace), client.MatchingLabels{m.label: "true"}); err != nil {
+		return nil, fmt.Errorf("cannot list github app secrets: %w", err)
+	}
+	secrets := list.Items
+	found := map[string]bool{}
+	for _, s := range secrets {
+		found[s.Name] = true
+	}
+	if !found[legacySecretName] {
+		legacy := &v1.Secret{}
+		if err := kube.Get(ctx, types.NamespacedName{Namespace: m.namespace, Name: legacySecretName}, legacy); err == nil {
+			secrets = append(secrets, *legacy)
+		}
+	}
+	sort.Slice(secrets, func(i, j int) bool { return secrets[i].Name < secrets[j].Name })
+	return secrets, nil
+}
+
+// ensureToken mints (or reuses) the installation token for one secret and
+// resolves the org it belongs to. Callers must hold m.mu.
+func (m *Manager) ensureToken(ctx context.Context, s v1.Secret) error {
+	if t := m.tokens[s.Name]; t.live(m.now()) && t.secretRV == s.ResourceVersion {
+		return nil
+	}
+
+	appID, err := strconv.ParseInt(string(s.Data["app_id"]), 10, 64)
+	if err != nil {
+		return fmt.Errorf("cannot parse app_id: %w", err)
+	}
+	installationID, err := strconv.ParseInt(string(s.Data["installation_id"]), 10, 64)
+	if err != nil {
+		return fmt.Errorf("cannot parse installation_id: %w", err)
+	}
+	privateKeyPEM := string(s.Data["github_app_private_key"])
+
+	appJWT, err := signAppJWT(appID, privateKeyPEM, m.now())
+	if err != nil {
+		return err
+	}
+	tok, expiresAt, err := m.mintInstallationToken(ctx, appJWT, installationID)
+	if err != nil {
+		return err
+	}
+	org, err := m.installationOrg(ctx, appJWT, installationID)
+	if err != nil {
+		return err
+	}
+
+	m.tokens[s.Name] = &tokenEntry{
+		org:       org,
+		token:     tok,
+		expiresAt: expiresAt,
+		secretRV:  s.ResourceVersion,
+		probed:    map[string]bool{},
+	}
+	return nil
+}
+
+// verifyRepoAccess probes org/repo with the matching cached token. Callers
+// must hold m.mu.
+func (m *Manager) verifyRepoAccess(ctx context.Context, org, repo string, failures []string) error {
+	var entry *tokenEntry
+	for _, t := range m.tokens {
+		if t.live(m.now()) && strings.EqualFold(t.org, org) {
+			entry = t
+			break
+		}
+	}
+	if entry == nil {
+		return fmt.Errorf("no github app installation covers org %q (have: %s)%s", org, strings.Join(m.orgs(), ", "), suffix(failures))
+	}
+	key := org + "/" + repo
+	if entry.probed[key] {
+		return nil
+	}
+
+	pctx, cancel := context.WithTimeout(ctx, probeTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(pctx, http.MethodGet, fmt.Sprintf("%s/repos/%s/%s", m.apiBase, org, repo), nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+entry.token)
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+
+	start := time.Now()
+	resp, err := m.httpClient.Do(req)
+	if err != nil {
+		// A network blip should not block a reconcile whose token was minted
+		// fine; let the clone be the judge.
+		metrics.RecordGitHubAPICall(org, "probe_repo", "failure", time.Since(start))
+		return nil //nolint:nilerr // deliberate: the probe is best-effort
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	switch {
+	case resp.StatusCode >= 200 && resp.StatusCode < 300:
+		metrics.RecordGitHubAPICall(org, "probe_repo", "success", time.Since(start))
+		entry.probed[key] = true
+		return nil
+	case resp.StatusCode == http.StatusNotFound:
+		metrics.RecordGitHubAPICall(org, "probe_repo", "failure", time.Since(start))
+		return fmt.Errorf("github app installation for org %q cannot access repository %q: check the installation's repository access", org, key)
+	default:
+		metrics.RecordGitHubAPICall(org, "probe_repo", "failure", time.Since(start))
+		return fmt.Errorf("github repository probe for %q returned status %d", key, resp.StatusCode)
+	}
+}
+
+func (m *Manager) orgs() []string {
+	orgs := make([]string, 0, len(m.tokens))
+	for _, t := range m.tokens {
+		if t.live(m.now()) {
+			orgs = append(orgs, t.org)
+		}
+	}
+	sort.Strings(orgs)
+	return orgs
+}
+
+func suffix(failures []string) string {
+	if len(failures) == 0 {
+		return ""
+	}
+	return " (" + strings.Join(failures, "; ") + ")"
+}
+
+// writeCredentialsFile atomically rewrites the shared credentials file with
+// one path-scoped line per live token. Callers must hold m.mu.
+func (m *Manager) writeCredentialsFile() error {
+	var b strings.Builder
+	for _, name := range m.sortedTokenNames() {
+		t := m.tokens[name]
+		if !t.live(m.now()) {
+			continue
+		}
+		fmt.Fprintf(&b, "https://x-access-token:%s@github.com/%s\n", t.token, t.org)
+	}
+	dir := filepath.Dir(m.credFile)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, CredentialsFile+".*")
+	if err != nil {
+		return err
+	}
+	if _, err := tmp.WriteString(b.String()); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmp.Name())
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmp.Name())
+		return err
+	}
+	return os.Rename(tmp.Name(), m.credFile)
+}
+
+func (m *Manager) sortedTokenNames() []string {
+	names := make([]string, 0, len(m.tokens))
+	for n := range m.tokens {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func signAppJWT(appID int64, privateKeyPEM string, now time.Time) (string, error) {
+	key, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(privateKeyPEM))
+	if err != nil {
+		return "", fmt.Errorf("cannot parse GitHub App private key: %w", err)
+	}
 	claims := jwt.RegisteredClaims{
 		IssuedAt:  jwt.NewNumericDate(now.Add(-60 * time.Second)), // Clock drift allowance
 		ExpiresAt: jwt.NewNumericDate(now.Add(10 * time.Minute)),  // Max 10 min per GitHub docs
 		Issuer:    fmt.Sprintf("%d", appID),
 	}
-
-	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
-	signedJWT, err := token.SignedString(key)
+	signed, err := jwt.NewWithClaims(jwt.SigningMethodRS256, claims).SignedString(key)
 	if err != nil {
-		return "", fmt.Errorf("failed to sign JWT: %w", err)
+		return "", fmt.Errorf("cannot sign GitHub App JWT: %w", err)
 	}
+	return signed, nil
+}
 
-	// Exchange JWT for installation access token
-	url := fmt.Sprintf("https://api.github.com/app/installations/%d/access_tokens", installationID)
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
+func (m *Manager) mintInstallationToken(ctx context.Context, appJWT string, installationID int64) (string, time.Time, error) {
+	url := fmt.Sprintf("%s/app/installations/%d/access_tokens", m.apiBase, installationID)
+	body, status, err := m.appAPICall(ctx, http.MethodPost, url, appJWT, "generate_installation_token")
 	if err != nil {
-		return "", fmt.Errorf("error creating installation token request: %w", err)
+		return "", time.Time{}, err
 	}
-
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", signedJWT))
-	req.Header.Set("Accept", "application/vnd.github.v3+json")
-
-	httpClient := &http.Client{Timeout: 30 * time.Second}
-	apiStart := time.Now()
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		metrics.RecordGitHubAPICall("unknown", "generate_installation_token", "failure", time.Since(apiStart))
-		return "", fmt.Errorf("error requesting installation token: %w", err)
+	if status != http.StatusCreated {
+		return "", time.Time{}, fmt.Errorf("cannot create installation token (status %d): %s", status, string(body))
 	}
-	defer func() { _ = resp.Body.Close() }()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		metrics.RecordGitHubAPICall("unknown", "generate_installation_token", "failure", time.Since(apiStart))
-		return "", fmt.Errorf("error reading installation token response: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusCreated {
-		metrics.RecordGitHubAPICall("unknown", "generate_installation_token", "failure", time.Since(apiStart))
-		return "", fmt.Errorf("failed to create installation token (status %d): %s", resp.StatusCode, string(body))
-	}
-
-	metrics.RecordGitHubAPICall("unknown", "generate_installation_token", "success", time.Since(apiStart))
-
 	var tokenResp installationTokenResponse
 	if err := json.Unmarshal(body, &tokenResp); err != nil {
-		return "", fmt.Errorf("error unmarshaling installation token response: %w", err)
+		return "", time.Time{}, fmt.Errorf("cannot unmarshal installation token response: %w", err)
 	}
+	return tokenResp.Token, tokenResp.ExpiresAt, nil
+}
 
-	return tokenResp.Token, nil
+func (m *Manager) installationOrg(ctx context.Context, appJWT string, installationID int64) (string, error) {
+	url := fmt.Sprintf("%s/app/installations/%d", m.apiBase, installationID)
+	body, status, err := m.appAPICall(ctx, http.MethodGet, url, appJWT, "get_installation")
+	if err != nil {
+		return "", err
+	}
+	if status != http.StatusOK {
+		return "", fmt.Errorf("cannot get installation %d (status %d): %s", installationID, status, string(body))
+	}
+	var inst struct {
+		Account struct {
+			Login string `json:"login"`
+		} `json:"account"`
+	}
+	if err := json.Unmarshal(body, &inst); err != nil {
+		return "", fmt.Errorf("cannot unmarshal installation response: %w", err)
+	}
+	if inst.Account.Login == "" {
+		return "", fmt.Errorf("installation %d has no account login", installationID)
+	}
+	return inst.Account.Login, nil
+}
+
+func (m *Manager) appAPICall(ctx context.Context, method, url, appJWT, operation string) ([]byte, int, error) {
+	req, err := http.NewRequestWithContext(ctx, method, url, nil)
+	if err != nil {
+		return nil, 0, fmt.Errorf("cannot create %s request: %w", operation, err)
+	}
+	req.Header.Set("Authorization", "Bearer "+appJWT)
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+
+	start := time.Now()
+	resp, err := m.httpClient.Do(req)
+	if err != nil {
+		metrics.RecordGitHubAPICall("unknown", operation, "failure", time.Since(start))
+		return nil, 0, fmt.Errorf("%s request failed: %w", operation, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		metrics.RecordGitHubAPICall("unknown", operation, "failure", time.Since(start))
+		return nil, 0, fmt.Errorf("cannot read %s response: %w", operation, err)
+	}
+	status := "success"
+	if resp.StatusCode >= 400 {
+		status = "failure"
+	}
+	metrics.RecordGitHubAPICall("unknown", operation, status, time.Since(start))
+	return body, resp.StatusCode, nil
+}
+
+// githubRepoPattern extracts the org and repository from a module source that
+// points at github.com, e.g.
+// "git::https://github.com/org/repo.git//modules/x?ref=main".
+var githubRepoPattern = regexp.MustCompile(`github\.com[:/]([^/]+)/([^/?#]+)`)
+
+// ParseGitHubRepo returns the org and repository name from a module URL, or
+// empty strings when module does not reference github.com.
+func ParseGitHubRepo(module string) (org, repo string) {
+	m := githubRepoPattern.FindStringSubmatch(module)
+	if len(m) < 3 {
+		return "", ""
+	}
+	repo = strings.TrimSuffix(m[2], ".git")
+	return m[1], repo
 }

--- a/internal/githubapp/githubapp_test.go
+++ b/internal/githubapp/githubapp_test.go
@@ -1,0 +1,262 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package githubapp
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func testPrivateKeyPEM(t *testing.T) string {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}))
+}
+
+func appSecret(name, rv, appID, installationID, key string) *v1.Secret {
+	return &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			Namespace:       DefaultSecretNamespace,
+			ResourceVersion: rv,
+			Labels:          map[string]string{DefaultSecretLabel: "true"},
+		},
+		Data: map[string][]byte{
+			"app_id":                 []byte(appID),
+			"installation_id":        []byte(installationID),
+			"github_app_private_key": []byte(key),
+		},
+	}
+}
+
+// fakeGitHub serves the three endpoints the manager uses. Installations map
+// installation id -> org; repos holds "org/repo" keys the tokens may access.
+type fakeGitHub struct {
+	installations map[string]string
+	repos         map[string]bool
+	mints         int
+}
+
+func (g *fakeGitHub) handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /app/installations/{id}/access_tokens", func(w http.ResponseWriter, r *http.Request) {
+		id := r.PathValue("id")
+		if _, ok := g.installations[id]; !ok {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		g.mints++
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprintf(w, `{"token":"ghs_%s","expires_at":%q}`, id, time.Now().Add(time.Hour).Format(time.RFC3339))
+	})
+	mux.HandleFunc("GET /app/installations/{id}", func(w http.ResponseWriter, r *http.Request) {
+		org, ok := g.installations[r.PathValue("id")]
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		fmt.Fprintf(w, `{"account":{"login":%q}}`, org)
+	})
+	mux.HandleFunc("GET /repos/{org}/{repo}", func(w http.ResponseWriter, r *http.Request) {
+		if g.repos[r.PathValue("org")+"/"+r.PathValue("repo")] {
+			fmt.Fprint(w, `{}`)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	})
+	return mux
+}
+
+func newTestManager(t *testing.T, gh *fakeGitHub) *Manager {
+	t.Helper()
+	srv := httptest.NewServer(gh.handler())
+	t.Cleanup(srv.Close)
+	m := NewManager()
+	m.apiBase = srv.URL
+	m.httpClient = srv.Client()
+	m.credFile = filepath.Join(t.TempDir(), CredentialsFile)
+	return m
+}
+
+func fakeKube(t *testing.T, objs ...client.Object) client.Client {
+	t.Helper()
+	return fake.NewClientBuilder().WithObjects(objs...).Build()
+}
+
+func TestEnsureCredentials(t *testing.T) {
+	key := testPrivateKeyPEM(t)
+	ctx := context.Background()
+
+	t.Run("MultiOrgWritesPathScopedLines", func(t *testing.T) {
+		gh := &fakeGitHub{
+			installations: map[string]string{"111": "konstructio", "222": "gitops-ing"},
+			repos:         map[string]bool{"konstructio/konstruct-templates": true},
+		}
+		m := newTestManager(t, gh)
+		kube := fakeKube(t,
+			appSecret("gh-konstructio", "1", "42", "111", key),
+			appSecret("gh-gitops-ing", "1", "42", "222", key),
+		)
+
+		module := "git::https://github.com/konstructio/konstruct-templates.git//terraform/aws?ref=main"
+		if err := m.EnsureCredentials(ctx, kube, module); err != nil {
+			t.Fatalf("EnsureCredentials(...): %v", err)
+		}
+
+		b, err := os.ReadFile(m.credFile)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := string(b)
+		for _, want := range []string{
+			"https://x-access-token:ghs_222@github.com/gitops-ing\n",
+			"https://x-access-token:ghs_111@github.com/konstructio\n",
+		} {
+			if !strings.Contains(got, want) {
+				t.Errorf("credentials file missing %q, got:\n%s", want, got)
+			}
+		}
+	})
+
+	t.Run("TokenAndProbeAreCached", func(t *testing.T) {
+		gh := &fakeGitHub{
+			installations: map[string]string{"111": "konstructio"},
+			repos:         map[string]bool{"konstructio/infra": true},
+		}
+		m := newTestManager(t, gh)
+		kube := fakeKube(t, appSecret("gh", "1", "42", "111", key))
+
+		module := "git::https://github.com/konstructio/infra.git?ref=v1"
+		for i := 0; i < 3; i++ {
+			if err := m.EnsureCredentials(ctx, kube, module); err != nil {
+				t.Fatalf("call %d: %v", i, err)
+			}
+		}
+		if gh.mints != 1 {
+			t.Errorf("want 1 token mint across repeat calls, got %d", gh.mints)
+		}
+	})
+
+	t.Run("RotatedSecretRemints", func(t *testing.T) {
+		gh := &fakeGitHub{installations: map[string]string{"111": "konstructio"}}
+		m := newTestManager(t, gh)
+
+		if err := m.EnsureCredentials(ctx, fakeKube(t, appSecret("gh", "1", "42", "111", key)), "inline"); err != nil {
+			t.Fatal(err)
+		}
+		if err := m.EnsureCredentials(ctx, fakeKube(t, appSecret("gh", "2", "42", "111", key)), "inline"); err != nil {
+			t.Fatal(err)
+		}
+		if gh.mints != 2 {
+			t.Errorf("want re-mint after secret rotation, got %d mints", gh.mints)
+		}
+	})
+
+	t.Run("RepoNotGrantedFails", func(t *testing.T) {
+		gh := &fakeGitHub{installations: map[string]string{"111": "konstructio"}}
+		m := newTestManager(t, gh)
+		kube := fakeKube(t, appSecret("gh", "1", "42", "111", key))
+
+		err := m.EnsureCredentials(ctx, kube, "git::https://github.com/konstructio/hidden.git")
+		if err == nil || !strings.Contains(err.Error(), "cannot access repository") {
+			t.Errorf("want repository access error, got: %v", err)
+		}
+	})
+
+	t.Run("OrgWithoutInstallationFails", func(t *testing.T) {
+		gh := &fakeGitHub{installations: map[string]string{"111": "konstructio"}}
+		m := newTestManager(t, gh)
+		kube := fakeKube(t, appSecret("gh", "1", "42", "111", key))
+
+		err := m.EnsureCredentials(ctx, kube, "git::https://github.com/other-org/repo.git")
+		if err == nil || !strings.Contains(err.Error(), `no github app installation covers org "other-org"`) {
+			t.Errorf("want no-installation error, got: %v", err)
+		}
+	})
+
+	t.Run("NoSecretsFails", func(t *testing.T) {
+		m := newTestManager(t, &fakeGitHub{})
+		err := m.EnsureCredentials(ctx, fakeKube(t), "git::https://github.com/o/r.git")
+		if err == nil || !strings.Contains(err.Error(), "no github app secrets found") {
+			t.Errorf("want no-secrets error, got: %v", err)
+		}
+	})
+
+	t.Run("BadSecretSkippedGoodSecretWins", func(t *testing.T) {
+		gh := &fakeGitHub{
+			installations: map[string]string{"111": "konstructio"},
+			repos:         map[string]bool{"konstructio/infra": true},
+		}
+		m := newTestManager(t, gh)
+		bad := appSecret("aaa-bad", "1", "not-a-number", "111", key)
+		kube := fakeKube(t, bad, appSecret("gh", "1", "42", "111", key))
+
+		if err := m.EnsureCredentials(ctx, kube, "git::https://github.com/konstructio/infra.git"); err != nil {
+			t.Fatalf("good secret should win despite bad sibling: %v", err)
+		}
+	})
+
+	t.Run("LegacyUnlabeledSecretHonored", func(t *testing.T) {
+		gh := &fakeGitHub{installations: map[string]string{"111": "konstructio"}}
+		m := newTestManager(t, gh)
+		legacy := appSecret(legacySecretName, "1", "42", "111", key)
+		legacy.Labels = nil
+		kube := fakeKube(t, legacy)
+
+		if err := m.EnsureCredentials(ctx, kube, "inline module, no github url"); err != nil {
+			t.Fatalf("legacy secret should be discovered: %v", err)
+		}
+	})
+}
+
+func TestParseGitHubRepo(t *testing.T) {
+	cases := map[string]struct{ module, org, repo string }{
+		"GoGetterWithSubdirAndRef": {"git::https://github.com/konstructio/konstruct-templates.git//terraform/aws/modules/x?ref=main", "konstructio", "konstruct-templates"},
+		"PlainHTTPS":               {"https://github.com/org/repo", "org", "repo"},
+		"NoScheme":                 {"github.com/org/repo//sub", "org", "repo"},
+		"SSHStyle":                 {"git@github.com:org/repo.git", "org", "repo"},
+		"NotGitHub":                {"git::https://gitlab.com/org/repo.git", "", ""},
+		"InlineHCL":                {"resource \"null_resource\" \"x\" {}", "", ""},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			org, repo := ParseGitHubRepo(tc.module)
+			if org != tc.org || repo != tc.repo {
+				t.Errorf("ParseGitHubRepo(%q) = %q,%q want %q,%q", tc.module, org, repo, tc.org, tc.repo)
+			}
+		})
+	}
+}

--- a/internal/githubapp/githubapp_test.go
+++ b/internal/githubapp/githubapp_test.go
@@ -22,11 +22,10 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -107,7 +106,6 @@ func newTestManager(t *testing.T, gh *fakeGitHub) *Manager {
 	m := NewManager()
 	m.apiBase = srv.URL
 	m.httpClient = srv.Client()
-	m.credFile = filepath.Join(t.TempDir(), CredentialsFile)
 	return m
 }
 
@@ -116,7 +114,7 @@ func fakeKube(t *testing.T, objs ...client.Object) client.Client {
 	return fake.NewClientBuilder().WithObjects(objs...).Build()
 }
 
-func TestEnsureCredentials(t *testing.T) {
+func TestGitCredentials(t *testing.T) {
 	key := testPrivateKeyPEM(t)
 	ctx := context.Background()
 
@@ -132,13 +130,9 @@ func TestEnsureCredentials(t *testing.T) {
 		)
 
 		module := "git::https://github.com/konstructio/konstruct-templates.git//terraform/aws?ref=main"
-		if err := m.EnsureCredentials(ctx, kube, module); err != nil {
-			t.Fatalf("EnsureCredentials(...): %v", err)
-		}
-
-		b, err := os.ReadFile(m.credFile)
+		b, err := m.GitCredentials(ctx, kube, module)
 		if err != nil {
-			t.Fatal(err)
+			t.Fatalf("GitCredentials(...): %v", err)
 		}
 		got := string(b)
 		for _, want := range []string{
@@ -161,7 +155,7 @@ func TestEnsureCredentials(t *testing.T) {
 
 		module := "git::https://github.com/konstructio/infra.git?ref=v1"
 		for i := 0; i < 3; i++ {
-			if err := m.EnsureCredentials(ctx, kube, module); err != nil {
+			if _, err := m.GitCredentials(ctx, kube, module); err != nil {
 				t.Fatalf("call %d: %v", i, err)
 			}
 		}
@@ -174,10 +168,10 @@ func TestEnsureCredentials(t *testing.T) {
 		gh := &fakeGitHub{installations: map[string]string{"111": "konstructio"}}
 		m := newTestManager(t, gh)
 
-		if err := m.EnsureCredentials(ctx, fakeKube(t, appSecret("gh", "1", "42", "111", key)), "inline"); err != nil {
+		if _, err := m.GitCredentials(ctx, fakeKube(t, appSecret("gh", "1", "42", "111", key)), "inline"); err != nil {
 			t.Fatal(err)
 		}
-		if err := m.EnsureCredentials(ctx, fakeKube(t, appSecret("gh", "2", "42", "111", key)), "inline"); err != nil {
+		if _, err := m.GitCredentials(ctx, fakeKube(t, appSecret("gh", "2", "42", "111", key)), "inline"); err != nil {
 			t.Fatal(err)
 		}
 		if gh.mints != 2 {
@@ -190,7 +184,7 @@ func TestEnsureCredentials(t *testing.T) {
 		m := newTestManager(t, gh)
 		kube := fakeKube(t, appSecret("gh", "1", "42", "111", key))
 
-		err := m.EnsureCredentials(ctx, kube, "git::https://github.com/konstructio/hidden.git")
+		_, err := m.GitCredentials(ctx, kube, "git::https://github.com/konstructio/hidden.git")
 		if err == nil || !strings.Contains(err.Error(), "cannot access repository") {
 			t.Errorf("want repository access error, got: %v", err)
 		}
@@ -201,17 +195,17 @@ func TestEnsureCredentials(t *testing.T) {
 		m := newTestManager(t, gh)
 		kube := fakeKube(t, appSecret("gh", "1", "42", "111", key))
 
-		err := m.EnsureCredentials(ctx, kube, "git::https://github.com/other-org/repo.git")
+		_, err := m.GitCredentials(ctx, kube, "git::https://github.com/other-org/repo.git")
 		if err == nil || !strings.Contains(err.Error(), `no github app installation covers org "other-org"`) {
 			t.Errorf("want no-installation error, got: %v", err)
 		}
 	})
 
-	t.Run("NoSecretsFails", func(t *testing.T) {
+	t.Run("NoSecretsIsSentinel", func(t *testing.T) {
 		m := newTestManager(t, &fakeGitHub{})
-		err := m.EnsureCredentials(ctx, fakeKube(t), "git::https://github.com/o/r.git")
-		if err == nil || !strings.Contains(err.Error(), "no github app secrets found") {
-			t.Errorf("want no-secrets error, got: %v", err)
+		_, err := m.GitCredentials(ctx, fakeKube(t), "git::https://github.com/o/r.git")
+		if !errors.Is(err, ErrNoSecrets) {
+			t.Errorf("want ErrNoSecrets, got: %v", err)
 		}
 	})
 
@@ -224,7 +218,7 @@ func TestEnsureCredentials(t *testing.T) {
 		bad := appSecret("aaa-bad", "1", "not-a-number", "111", key)
 		kube := fakeKube(t, bad, appSecret("gh", "1", "42", "111", key))
 
-		if err := m.EnsureCredentials(ctx, kube, "git::https://github.com/konstructio/infra.git"); err != nil {
+		if _, err := m.GitCredentials(ctx, kube, "git::https://github.com/konstructio/infra.git"); err != nil {
 			t.Fatalf("good secret should win despite bad sibling: %v", err)
 		}
 	})
@@ -236,8 +230,12 @@ func TestEnsureCredentials(t *testing.T) {
 		legacy.Labels = nil
 		kube := fakeKube(t, legacy)
 
-		if err := m.EnsureCredentials(ctx, kube, "inline module, no github url"); err != nil {
+		b, err := m.GitCredentials(ctx, kube, "inline module, no github url")
+		if err != nil {
 			t.Fatalf("legacy secret should be discovered: %v", err)
+		}
+		if !strings.Contains(string(b), "github.com/konstructio") {
+			t.Errorf("want konstructio line, got: %s", b)
 		}
 	})
 }


### PR DESCRIPTION
## Problem
Git credentials were minted from a single hardcoded secret (`crossplane-system/github-app-credentials`) with one `installation_id`, so the provider could clone modules from **one** GitHub org only. Our clusters already reference two (`konstructio`, `gitops-ing`).

## Design
**Labeled secrets → cached mint → repo probe → per-workspace credentials file (existing $GIT_CRED_DIR flow)**, ProviderConfig-secretRef fallback only when no App secrets exist.

- **Discovery**: all Secrets in `crossplane-system` labeled `tf.konstruct.io/github-app: "true"` — one per installation. Same App in N orgs = N secrets sharing `app_id`/private key with distinct `installation_id`s; a different App also works. The legacy unlabeled `github-app-credentials` secret keeps working. Adding an org = `kubectl apply` one secret.
- **Org resolution**: from the GitHub API (`GET /app/installations/{id}` → `account.login`) — no `org` key needed in the secret.
- **Token cache**: minted once per secret, reused until ~5 min before the 1 h expiry, invalidated on secret rotation. (Previously a fresh token was minted every reconcile.)
- **Delivery**: the manager returns one path-scoped line per org (`https://x-access-token:<tok>@github.com/<org>`); Connect writes them through the **pre-existing per-workspace `$GIT_CRED_DIR` file** — no new paths or helpers. Every workspace gets identical content, so concurrent reconciles stay consistent. `useHttpPath = true` added to the gitconfig so git picks the token by repository path. Also covers inline HCL referencing private github.com module sources.
- **Probe**: for github.com module URLs, `GET /repos/{org}/{repo}` with that org's token — "App not installed on org X" / "repo not granted" land as clear `Synced` condition messages instead of opaque clone failures. Probed once per token lifetime; network errors are non-fatal.
- **Fallback semantics (tightened per review)**: App secrets present ⇒ **authoritative** — any failure surfaces as the Connect error. ProviderConfig creds are used only on the `ErrNoSecrets` sentinel (GitLab installs), never to mask a misconfigured App.

## Secret shape (per org)
```yaml
apiVersion: v1
kind: Secret
metadata:
  name: github-app-konstructio
  namespace: crossplane-system
  labels:
    tf.konstruct.io/github-app: "true"
stringData:
  app_id: "123456"
  installation_id: "789012"
  github_app_private_key: |
    -----BEGIN RSA PRIVATE KEY-----...
```
Namespace/label overridable via `GITHUB_APP_SECRET_NAMESPACE` / `GITHUB_APP_SECRET_LABEL`.

## Rollout
1. Merge + release image.
2. Label the existing secret (or leave it — legacy name honored) and add one secret per additional org.
3. No ProviderConfig/Workspace changes.

Note: the label is a trust boundary — anyone who can create labeled secrets in `crossplane-system` controls what the provider clones with.

## Tests
- `internal/githubapp`: multi-org credential lines, token+probe caching (1 mint across repeated calls), re-mint on secret rotation, repo-not-granted error, org-without-installation error, `ErrNoSecrets` sentinel, bad secret skipped when a good one exists, legacy secret discovery; `ParseGitHubRepo` table.
- Both controllers: `TestConnect` suites pass with the manager stubbed to `ErrNoSecrets` → proves the ProviderConfig fallback end to end.
- `go test ./...` green; `golangci-lint v2.13.1` (CI's version): 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)